### PR TITLE
feat(web): improve onboarding and game initialization UX

### DIFF
--- a/web/src/app/game/page.module.css
+++ b/web/src/app/game/page.module.css
@@ -1,0 +1,82 @@
+.main {
+  padding: 20px 8px 28px;
+  text-align: center;
+  background: linear-gradient(to bottom, #1a1a2e, #16213e);
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.title {
+  font-size: clamp(1.5rem, 6vw, 2rem);
+  margin: 0 0 8px;
+  color: #f4a261;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.description {
+  font-size: clamp(0.82rem, 3vw, 1rem);
+  margin: 0 0 14px;
+  color: #e9c46a;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+.gameFrame {
+  width: min(90vw, 420px);
+  aspect-ratio: 420 / 480;
+  max-height: 480px;
+  border: 2px solid #e76f51;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  margin: 0 auto;
+  overflow: hidden;
+  position: relative;
+}
+
+.statusOverlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 15, 25, 0.82);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffd166;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  padding: 12px;
+}
+
+.actions {
+  margin-top: 14px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.linkButton,
+.reloadButton {
+  border: 1px solid rgba(255, 209, 102, 0.65);
+  background: rgba(0, 0, 0, 0.25);
+  color: #f8f9fa;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.debug {
+  margin-top: 14px;
+  background: #111;
+  color: #0f0;
+  padding: 12px;
+  font-size: clamp(10px, 2.5vw, 12px);
+  max-width: min(90vw, 420px);
+  white-space: pre-wrap;
+  border-radius: 4px;
+  overflow: auto;
+  text-align: left;
+}

--- a/web/src/app/game/page.tsx
+++ b/web/src/app/game/page.tsx
@@ -1,13 +1,20 @@
-"use client"
+'use client'
+
+import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
-import { asset } from '@/lib/assets'
 import Mama from '@/components/Mama'
 import MasakiPopup from '@/components/MasakiPopup'
+import styles from './page.module.css'
+
+type InitState = 'loading' | 'ready' | 'error'
 
 export default function GamePage() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [log, setLog] = useState<string[]>([])
+  const [initState, setInitState] = useState<InitState>('loading')
+
   const push = (m: string) => setLog((L) => [...L, m])
+
   useEffect(() => {
     if (!containerRef.current) return
     const parent = containerRef.current
@@ -16,9 +23,12 @@ export default function GamePage() {
     const onError = (e: any) => {
       const msg = e?.reason?.message || e?.message || String(e)
       push(`Error: ${msg}`)
+      setInitState('error')
     }
+
     window.addEventListener('unhandledrejection', onError)
     window.addEventListener('error', onError as any)
+
     ;(async () => {
       try {
         push('loading phaser...')
@@ -38,16 +48,18 @@ export default function GamePage() {
           backgroundColor: '#0b0f19',
           pixelArt: true,
           scene: [MainScene],
-          scale: { 
-            mode: Scale.FIT, 
+          scale: {
+            mode: Scale.FIT,
             autoCenter: Scale.CENTER_BOTH,
             width: 420,
-            height: 480
+            height: 480,
           },
         })
         push('game created')
+        setInitState('ready')
       } catch (err: any) {
         push(`init failed: ${err?.message || String(err)}`)
+        setInitState('error')
       }
     })()
 
@@ -59,65 +71,33 @@ export default function GamePage() {
   }, [])
 
   return (
-    <main style={{ 
-      padding: '8px', 
-      textAlign: 'center',
-      background: 'linear-gradient(to bottom, #1a1a2e, #16213e)',
-      color: '#fff',
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'flex-start',
-      alignItems: 'center',
-      paddingTop: '20px'
-    }}>
-      <h1 style={{ 
-        fontSize: 'clamp(1.5rem, 6vw, 2rem)', 
-        marginBottom: '0.5rem',
-        color: '#f4a261',
-        margin: '0 0 8px 0',
-        textShadow: '2px 2px 4px rgba(0,0,0,0.5)',
-        fontWeight: 'bold'
-      }}>🍻 ちょい吉パズル 🍻</h1>
-      <p style={{ 
-        fontSize: 'clamp(0.8rem, 3vw, 1rem)', 
-        marginBottom: '16px',
-        color: '#e9c46a',
-        margin: '0 0 16px 0',
-        textShadow: '1px 1px 2px rgba(0,0,0,0.5)'
-      }}>⏰ 60秒でおつまみを揃えてね！ ⏰</p>
-      <div 
-        ref={containerRef} 
-        style={{ 
-          width: 'min(90vw, 420px)', 
-          height: 'min(90vw * 480/420, 480px)', 
-          maxWidth: '420px',
-          maxHeight: '480px',
-          border: '2px solid #e76f51',
-          borderRadius: '8px',
-          boxShadow: '0 4px 8px rgba(0,0,0,0.3)',
-          margin: '0 auto'
-        }} 
-      />
-      {/* ママはゲーム枠外に表示 */}
+    <main className={styles.main}>
+      <h1 className={styles.title}>🍻 ちょい吉パズル 🍻</h1>
+      <p className={styles.description}>⏰ 60秒でおつまみを揃えてね！ ⏰</p>
+
+      <div ref={containerRef} className={styles.gameFrame}>
+        {initState !== 'ready' && (
+          <div className={styles.statusOverlay}>
+            {initState === 'loading'
+              ? 'ゲームを準備中です…\n少しお待ちください。'
+              : '初期化に失敗しました。\n再読み込みをお試しください。'}
+          </div>
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        <button type="button" className={styles.reloadButton} onClick={() => window.location.reload()}>
+          再読み込み
+        </button>
+        <Link href="/" className={styles.linkButton}>
+          タイトルへ戻る
+        </Link>
+      </div>
+
       <Mama />
-      {/* masakiポップアップ */}
       <MasakiPopup />
-      {log.length > 0 && (
-        <pre style={{ 
-          marginTop: '16px', 
-          background: '#111', 
-          color: '#0f0', 
-          padding: '12px', 
-          fontSize: 'clamp(10px, 2.5vw, 12px)', 
-          maxWidth: 'min(90vw, 420px)', 
-          whiteSpace: 'pre-wrap',
-          borderRadius: '4px',
-          overflow: 'auto'
-        }}>
-          {log.join('\n')}
-        </pre>
-      )}
+
+      {initState === 'error' && log.length > 0 && <pre className={styles.debug}>{log.join('\n')}</pre>}
     </main>
   )
 }

--- a/web/src/app/page.module.css
+++ b/web/src/app/page.module.css
@@ -1,167 +1,72 @@
-.page {
-  --gray-rgb: 0, 0, 0;
-  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
-  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-
-  display: grid;
-  grid-template-rows: 20px 1fr 20px;
-  align-items: center;
-  justify-items: center;
-  min-height: 100svh;
-  padding: 80px;
-  gap: 64px;
-  font-family: var(--font-geist-sans);
-}
-
-@media (prefers-color-scheme: dark) {
-  .page {
-    --gray-rgb: 255, 255, 255;
-    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-  }
-}
-
 .main {
+  min-height: 100vh;
+  padding: 24px 16px 40px;
+  background: linear-gradient(to bottom, #1a1a2e, #16213e);
+  color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  grid-row-start: 2;
-}
-
-.main ol {
-  font-family: var(--font-geist-mono);
-  padding-left: 0;
-  margin: 0;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  list-style-position: inside;
-}
-
-.main li:not(:last-of-type) {
-  margin-bottom: 8px;
-}
-
-.main code {
-  font-family: inherit;
-  background: var(--gray-alpha-100);
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-weight: 600;
-}
-
-.ctas {
-  display: flex;
-  gap: 16px;
-}
-
-.ctas a {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: 1px solid transparent;
-  transition:
-    background 0.2s,
-    color 0.2s,
-    border-color 0.2s;
-  cursor: pointer;
-  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 500;
-}
-
-a.primary {
-  background: var(--foreground);
-  color: var(--background);
-  gap: 8px;
-}
-
-a.secondary {
-  border-color: var(--gray-alpha-200);
-  min-width: 158px;
-}
-
-.footer {
-  grid-row-start: 3;
-  display: flex;
   gap: 24px;
 }
 
-.footer a {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.hero {
+  text-align: center;
 }
 
-.footer img {
-  flex-shrink: 0;
+.title {
+  font-size: clamp(1.9rem, 8vw, 2.8rem);
+  line-height: 1.2;
+  color: #f4a261;
+  margin: 0 0 12px;
 }
 
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-
-  .footer a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
+.subtitle {
+  font-size: clamp(1rem, 4vw, 1.2rem);
+  color: #e9c46a;
+  line-height: 1.5;
+  margin: 0 auto 20px;
+  max-width: 28rem;
 }
 
-@media (max-width: 600px) {
-  .page {
-    padding: 32px;
-    padding-bottom: 80px;
-  }
-
-  .main {
-    align-items: center;
-  }
-
-  .main ol {
-    text-align: center;
-  }
-
-  .ctas {
-    flex-direction: column;
-  }
-
-  .ctas a {
-    font-size: 14px;
-    height: 40px;
-    padding: 0 16px;
-  }
-
-  a.secondary {
-    min-width: auto;
-  }
-
-  .footer {
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-  }
+.startButton {
+  display: inline-block;
+  min-width: 220px;
+  padding: 14px 28px;
+  border-radius: 10px;
+  color: #fff;
+  background: #e76f51;
+  text-decoration: none;
+  font-size: clamp(1rem, 4vw, 1.15rem);
+  font-weight: 700;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease, filter 0.15s ease;
 }
 
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
-  }
+.startButton:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+}
+
+.helpCard {
+  width: min(92vw, 480px);
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 209, 102, 0.5);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
+
+.helpTitle {
+  margin: 0 0 10px;
+  color: #ffd166;
+  font-size: 1.05rem;
+}
+
+.helpList {
+  margin: 0;
+  padding-left: 20px;
+  color: #f8f9fa;
+  line-height: 1.6;
+  font-size: 0.95rem;
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,50 +1,25 @@
 import Link from 'next/link'
+import styles from './page.module.css'
 
 export default function Home() {
   return (
-    <main style={{ 
-      padding: '16px', 
-      textAlign: 'center',
-      background: 'linear-gradient(to bottom, #1a1a2e, #16213e)',
-      color: '#fff',
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center'
-    }}>
-      <h1 style={{ 
-        fontSize: 'clamp(1.8rem, 8vw, 2.5rem)', 
-        marginBottom: '1rem',
-        color: '#f4a261',
-        lineHeight: 1.2
-      }}>ちょい吉パズル</h1>
-      <p style={{ 
-        fontSize: 'clamp(1rem, 4vw, 1.2rem)', 
-        marginBottom: '2rem',
-        color: '#e9c46a',
-        maxWidth: '90vw',
-        lineHeight: 1.4
-      }}>金沢市の立ち呑み処「ちょい吉」のマッチ3パズル</p>
-      
-      <div style={{ marginTop: '24px' }}>
-        <Link href="/game" style={{
-          display: 'inline-block', 
-          padding: '16px 32px', 
-          background: '#e76f51',
-          color: '#fff', 
-          borderRadius: '8px', 
-          textDecoration: 'none', 
-          fontWeight: 700,
-          fontSize: 'clamp(1rem, 4vw, 1.2rem)',
-          boxShadow: '0 4px 8px rgba(0,0,0,0.3)',
-          transition: 'transform 0.2s',
-          minWidth: '200px',
-          textAlign: 'center'
-        }}>
+    <main className={styles.main}>
+      <div className={styles.hero}>
+        <h1 className={styles.title}>ちょい吉パズル</h1>
+        <p className={styles.subtitle}>金沢市の立ち呑み処「ちょい吉」のマッチ3パズル</p>
+        <Link href="/game" className={styles.startButton}>
           ゲームスタート！
         </Link>
       </div>
+
+      <section className={styles.helpCard} aria-label="遊び方">
+        <h2 className={styles.helpTitle}>遊び方</h2>
+        <ul className={styles.helpList}>
+          <li>隣り合うおつまみを入れ替えて3つ以上そろえる</li>
+          <li>60秒でできるだけ高得点を目指す</li>
+          <li>5個以上そろえるとボーナス＆フィーバー加速</li>
+        </ul>
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Improve first-time user onboarding and make game initialization failures and loading state clear and recoverable for a smoother UX.

### Description
- Moved homepage inline styles into `web/src/app/page.module.css` and added a hero section plus a “遊び方” (How to play) card to clarify the entry experience.
- Reworked the game entry page to use `web/src/app/game/page.module.css`, introduced an `InitState` lifecycle (`loading` / `ready` / `error`) with a loading/error overlay, and added reload and back-to-title actions under the game frame.
- Suppressed persistent debug output during normal play by showing the internal debug log only when initialization errors occur, while keeping existing `Mama` and `MasakiPopup` components integrated.
- Key files changed: `web/src/app/page.tsx`, `web/src/app/page.module.css`, `web/src/app/game/page.tsx`, and added `web/src/app/game/page.module.css`.

### Testing
- Ran `npm run type-check` which completed successfully with no type errors.
- Ran `npm run lint` which failed in this environment due to legacy `next lint` options being incompatible with the installed tooling.
- Commands executed during validation: `npm run type-check` and `npm run lint`, with `type-check` ✅ and `lint` ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1317d8d38832c8fa39ff0150a78b3)